### PR TITLE
Batch query eval

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/inpars/query_eval.py
+++ b/inpars/query_eval.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Union, Dict, Tuple
 import logging
 from pathlib import Path
+import json
 
 import torch
 import numpy as np
@@ -15,74 +16,48 @@ logger = logging.getLogger(__name__)
 class QueryEval(torch.nn.Module):
     def __init__(
         self,
-        models: List[str] = ["bm25", "sentence-transformers/all-mpnet-base-v2"],
+        dense: str = "sentence-transformers/all-mpnet-base-v2",
+        bm25: bool = True,
         weights: List[float] = [0.5, 0.5],
         device: Optional[str] = None
     ):
         super(QueryEval, self).__init__()
+        assert sum(weights) == 1, "Weights should sum to 1."
+        self.weights = torch.tensor(weights).cpu()
         self.device = device or ('cuda' if torch.cuda.is_available() else 'cpu')
-        self.models = OrderedDict()
-        self.tokenizers = OrderedDict()
-        for model in models:
-            if model == "bm25":
-                self.models["bm25"] = None # initialised with the corpus
-            else:
-                self.tokenizers[model] = AutoTokenizer.from_pretrained(model)
-                self.models[model] = AutoModel.from_pretrained(model).to(self.device)
-        self.weights = OrderedDict({model: weight for model, weight in zip(models, weights)})
-        self.doc_embeddings = OrderedDict()
+        self.dense_name = dense
+        self.dense =  ( # keep everything on cpu by default to avoid memory issues
+            AutoModel.from_pretrained(dense).to('cpu'),
+            AutoTokenizer.from_pretrained(dense)
+        )
+        self.bm25 = bm25 # to be instantiated when the dataset is loaded
+        self.doc_embeddings = None
+        self.doc_id2idx = None
 
     def _mean_pooling(self, token_embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         """Perform mean pooling on token embeddings using attention mask"""
         token_embeddings = token_embeddings.masked_fill(~attention_mask[..., None].bool(), 0.)
         return token_embeddings.sum(dim=1) / attention_mask.sum(dim=1)[..., None]
 
-    def _get_embeddings(self, model_name, documents: List[str], batch_size: int) -> torch.Tensor:
+    def _get_embeddings(self, texts: List[str]) -> torch.Tensor:
         """
-            Compute embeddings for a list of documents
+            Compute embeddings for a list of documents.
+            NOTE: Loads the model and tokenizer to the device and does not release it.
             Inputs:
-                model_name: Name of the model to use
-                documents: A list of D documents
+                texts: A batch of texts to embed for each model
             Returns:
-                List of embeddings for the given documents computed by the given model.
+                A Tensor of shape (len(texts), embedding_dim)
+                containing the embeddings for the dense encoder model.
         """
-        embeddings = []
-        if model_name not in self.tokenizers:
-            raise ValueError(f"No tokenizer for {model_name}.")
-
-        tokenizer = self.tokenizers[model_name]
-        model = self.models[model_name]
         with torch.no_grad():
-            inputs = tokenizer(documents, padding=True, truncation=True, return_tensors='pt').to(self.device)
-            outputs = model(**inputs)
-            embeddings = self._mean_pooling(outputs.last_hidden_state, inputs['attention_mask']).to(self.device)
+            model, tokenizer = self.dense
+            model.to(self.device)
 
-        # sanity check
-        assert embeddings.shape[0] == len(documents), f"sanity check failed: {embeddings.shape[0]} != {len(documents)}"
-        assert embeddings.shape[1] == model.config.hidden_size, f"sanity check failed: {embeddings.shape[1]} != {outputs.size(-1)}"
-        return embeddings
-
-    def load_from_cache(self, cache_path: Path) -> None:
-        """Load precomputed embeddings from cache.
-        Args:
-            cache_path: Path to the cache file
-        Loads a pandas DataFrame with columns ['doc_id', 'embedding'] from the cache file.
-        """
-        self.doc_embeddings = torch.load(cache_path)
-        if "bm25" in self.models:
-            self.models["bm25"] = BM25.load(
-                cache_path.parent.absolute() / f"{cache_path.stem}_bm25{cache_path.suffix}")
-
-    def save_to_cache(self, cache_path: Path) -> None:
-        """Save precomputed embeddings to cache.
-        Args:
-            cache_path: Path to the cache file
-        Saves a pandas DataFrame with columns ['doc_id', 'embedding'] to the cache file.
-        """
-        torch.save(self.doc_embeddings, cache_path)
-        if "bm25" in self.models:
-            self.models["bm25"].save(cache_path.parent.absolute(
-            ) / f"{cache_path.stem}_bm25{cache_path.suffix}")
+            inputs = tokenizer(texts, padding=True,
+                               truncation=True, return_tensors='pt').to(self.device) # B x T
+            outputs = model(**inputs) # B x D
+            embeddings = self._mean_pooling(outputs.last_hidden_state, inputs['attention_mask']).to(self.device) # B x D
+        return embeddings # B x M x D_max
 
     def load_dataset(self,
                      documents: pd.DataFrame,
@@ -101,54 +76,77 @@ class QueryEval(torch.nn.Module):
         if documents is None:
             raise ValueError("No documents nor a valid path provided to load_dataset.")
 
-        def embed_for_model(model_name) -> Union[Dict[str, Tuple[int, List[str]]], pd.DataFrame]:
-            """
-            Compute embeddings for the given corpus and model.
-            - If the model is a BM25 model, return the tokenized text, 
-                including the integer index of the documents in the corpus.
-                We need these indices to identify the documents in the output
-                of the BM25.get_scores method.
-            - Otherwise, embed the documents in batches and
-                store the embeddings in a pd.DataFrame.
-            """
-            if model_name == "bm25":
-                texts = OrderedDict({
-                    doc_id: (idx, text.split()) for idx, (doc_id, text) in enumerate(documents[['doc_id', 'text']].values)
-                })
-                # split the text into tokens
-                return texts
-            # otherwise, iterate over the list of documents,
-            # embed them in batches and
-            # store the embeddings in a pd.DataFrame
-            embeddings = pd.DataFrame(columns=['doc_id', 'embedding'])
-            for i in tqdm(range(0, len(documents), batch_size), desc=f"Computing embeddings for {model_name}"):
-                batch = documents[i:i + batch_size]
-                embeddings_batch = self._get_embeddings(model_name, batch['text'].tolist(), batch_size)
-                embeddings = pd.concat([embeddings, pd.DataFrame({
-                    'doc_id': batch['doc_id'].tolist(),
-                    'embedding': embeddings_batch.cpu().tolist()
-                })], ignore_index=True)
-            return embeddings
+        logger.info("Computing embeddings for %s%s", self.dense_name,
+                    " and BM25" if self.bm25 else "")
+        # save the mapping of doc_id to index
+        self.doc_id2idx = {doc_id: idx for idx, doc_id in enumerate(documents['doc_id'])}
+        # compute embeddings for each model and store them on cpu
+        documents = documents['text'].tolist()
+        self.doc_embeddings = []
+        for i in tqdm(range(0, len(documents), batch_size), desc="Computing embeddings"):
+            batch = documents[i:i+batch_size]
+            embeddings = self._get_embeddings(batch).cpu()
+            self.doc_embeddings.append(embeddings)
+        # concatenate
+        self.doc_embeddings = torch.cat(self.doc_embeddings, dim=1)
+        logger.debug("nr of documents: %d", len(documents))
+        logger.debug("Document embeddings shape: %s", self.doc_embeddings.shape)
 
-        logger.info("Computing embeddings for %d models", len(self.models))
-        self.doc_embeddings = OrderedDict({model_name: embed_for_model(model_name)
-                               for model_name in self.models.keys()})
+        # initialize the bm25 model
+        if self.bm25:
+            docs = [doc.split() for doc in documents]
+            self.bm25 = BM25()
+            self.bm25.index(docs)
 
-        if "bm25" in self.doc_embeddings:
-            self.models["bm25"] = BM25()
-            self.models["bm25"].index([text for _, text in self.doc_embeddings["bm25"].values()])
+        logger.info("Document corpus loaded successfully")
 
-        # sanity
-        assert all([len(embeddings["embedding"].to_numpy()[0]) == self.models[model_name].config.hidden_size
-                    for model_name, embeddings in self.doc_embeddings.items()
-                    if model_name != "bm25"]), f"sanity check: model embedding doesn't match with the model's hidden size"
+    def _prepare_cache(self, cache_path: Path) -> None:
+        index_path = cache_path / "index.json"
+        embedding_path = cache_path / "embeddings.pt"
+        bm25_path = cache_path / "bm25.pkl"
+        return index_path, embedding_path, bm25_path
 
-        logger.info("Document embeddings computed successfully")
+    def save_to_cache(self, cache_path: Path) -> None:
+        """Save precomputed embeddings to cache.
+        Args:
+            cache_path: Path to the cache directory
+        Saves a pandas DataFrame with columns ['doc_id', 'embedding'] to the cache file.
+        """
+        if not cache_path.exists():
+            cache_path.mkdir(parents=True)
+        index_path, embedding_path, bm25_path = self._prepare_cache(cache_path)
+        with open(index_path, "w") as f:
+            json.dump(self.doc_id2idx, f)
+        torch.save(self.doc_embeddings, embedding_path)
+        if self.bm25:
+            self.bm25.save(bm25_path)
+        logger.info("Saved embeddings to %s", cache_path)
+
+    def load_from_cache(self, cache_path: Path) -> None:
+        """Load precomputed embeddings from cache.
+        Args:
+            cache_path: Path to the cache file
+        Loads a pandas DataFrame with columns ['doc_id', 'embedding'] from the cache file.
+        """
+        if not cache_path.exists() or not cache_path.is_dir():
+            raise ValueError("Cache directory does not exist.")
+        index_path, embedding_path, bm25_path = self._prepare_cache(cache_path)
+        if not index_path.exists():
+            raise ValueError("Index file not found in cache.")
+        if not embedding_path.exists():
+            raise ValueError("Embedding file not found in cache.")
+        if self.bm25 and not bm25_path.exists():
+            raise ValueError("BM25 file not found in cache.")
+        with open(index_path, "r") as f:
+            self.doc_id2idx = json.load(f)
+        self.doc_embeddings = torch.load(embedding_path)
+        if self.bm25:
+            self.bm25 = BM25.load(bm25_path)
+        logger.info("Loaded embeddings from %s", cache_path)
 
     def score(self,
-                queries: Union[str, List[str]],
-                doc_indices: Union[str, List[int]] = None,
-                batch_size: int = 32) -> torch.Tensor:
+              queries: Union[str, List[str]],
+              doc_indices: Union[str, List[str]]) -> torch.Tensor:
         """Compute similarity scores between query and documents.
 
         Args:
@@ -165,76 +163,50 @@ class QueryEval(torch.nn.Module):
         logger.info("Computing similarity scores")
         if isinstance(queries, str):
             queries = [queries]
-        if isinstance(doc_indices, int):
+        if isinstance(doc_indices, str):
             doc_indices = [doc_indices]
         if len(queries) != len(doc_indices):
             raise ValueError("Number of queries and document indices should be the same.")
 
         # find the embeddings corresponding to the doc_indices in the dataframes
-        doc_embeddings = OrderedDict({
-            model_name: torch.tensor(
-                self.doc_embeddings[model_name].loc[
-                    self.doc_embeddings[model_name]['doc_id'].isin(doc_indices), 'embedding'
-                ].values.tolist(),
-                device=self.device
-            )
-            for model_name in self.doc_embeddings.keys()
-            if model_name != "bm25"
-        })
+        doc_indices = [self.doc_id2idx[doc_id] for doc_id in doc_indices]
+        # load relevant embeddings to device
+        doc_embeddings = self.doc_embeddings[doc_indices].to(self.device)
 
-        # embed the queries in the same order
-        query_embeddings = OrderedDict({model_name: self._get_embeddings(model_name, queries, batch_size)
-                                        for model_name in self.doc_embeddings.keys()
-                                        if model_name != "bm25"})
+        # embed the queries and load to device.
+        model, tokenizer = self.dense
+        model.to(self.device)
+        query_embeddings = self._get_embeddings(queries).to(self.device)
+        # release the dense model
+        model.cpu()
 
-        # embedding dimensions differ from model to model,
-        # so we have to do one by one
-        similarities = OrderedDict({
-            # compute cosine similarity between query and document embeddings
-            # and rescale it to [0, 1] so we can regard it as a probability
-            # NOTE: this is a coarse approximation because we don't want to compute softmax over the whole corpus.
-            #       Instead, we can adjust the weights to make the scores comparable.
-            model_name: 
-                (1 + torch.cosine_similarity(
-                        query_embeddings[model_name], doc_embeddings[model_name]).to(self.device)
-                 ) / 2
-            for model_name in self.doc_embeddings.keys()
-            if model_name != "bm25"
-        })
-        # do the same for BM25
-        if "bm25" in self.models:
-            # select the numeric indices of the requested documents
-            doc_idxs = [self.doc_embeddings["bm25"][d][0] for d in doc_indices]
+        # compute cosine similarity and scale to [0, 1]
+        # shape is len(queries)
+        similarities: List[torch.Tensor] = [(
+            1 + torch.cosine_similarity(query_embeddings, doc_embeddings)
+        ) / 2]
+
+        if self.bm25:
             scores = []
-            for q, d in zip(queries, doc_idxs):
-                bm25: BM25 = self.models["bm25"]
-                # compute raw bm25 scores for all the documents in the corput
+            for q, d in zip(queries, doc_indices):
+                bm25: BM25 = self.bm25
+                # compute raw bm25 scores for all the documents in the corpus
                 alldocs = torch.tensor(bm25.get_scores(q.split()))
                 # send to device
                 alldocs = alldocs.to(self.device).squeeze()
-                # normalise to get "probabilities" 
-                # opposed to dense vectors, here we have no choice but to consider the whole corpus.
+                # normalise to get "probabilities"
+                # opposed to dense vectors, here we have
+                # no choice but to consider the whole corpus.
                 alldocs = alldocs.softmax(dim=0)
                 # select the score of the requested document
                 scores.append(alldocs[d])
-            similarities["bm25"] = torch.tensor(scores).to(self.device)
+            similarities.append(torch.tensor(scores).to(self.device))
 
-        # apply weights
-        similarities = torch.stack([
-                similarities[model_name] * self.weights[model_name]
-                for model_name in similarities.keys()
-            ]).to(self.device)
-        # compute weighted average of similarities
-        weighted_mean = torch.mean(similarities, dim=0)
+        similarities = torch.stack(similarities, dim=1)
 
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Overall similarity score: %s", weighted_mean)
-            for model_name, sim in similarities.items():
-                logger.debug("Similarity score using %s: %s", model_name, sim)
-            if "bm25" in self.models:
-                logger.debug("Similarity score using BM25: %s", similarities["bm25"])
+        weighted_sums = similarities @ self.weights.to(self.device)
 
-        return weighted_mean.squeeze()
+        return weighted_sums.squeeze()
 
     def forward(self, query: Union[str, List[str]], doc_indices: Optional[List[int]] = None) -> torch.Tensor:
         return self.score(query, doc_indices)

--- a/inpars/query_eval.py
+++ b/inpars/query_eval.py
@@ -26,7 +26,7 @@ class QueryEval(torch.nn.Module):
         self.weights = torch.tensor(weights).cpu()
         self.device = device or ('cuda' if torch.cuda.is_available() else 'cpu')
         self.dense_name = dense
-        self.dense =  ( # keep everything on cpu by default to avoid memory issues
+        self.dense =  (
             AutoModel.from_pretrained(dense).to('cpu'),
             AutoTokenizer.from_pretrained(dense)
         )
@@ -85,7 +85,7 @@ class QueryEval(torch.nn.Module):
         self.doc_embeddings = []
         for i in tqdm(range(0, len(documents), batch_size), desc="Computing embeddings"):
             batch = documents[i:i+batch_size]
-            embeddings = self._get_embeddings(batch).cpu()
+            embeddings = self._get_embeddings(batch)
             self.doc_embeddings.append(embeddings)
         # concatenate
         self.doc_embeddings = torch.cat(self.doc_embeddings, dim=1)
@@ -174,11 +174,7 @@ class QueryEval(torch.nn.Module):
         doc_embeddings = self.doc_embeddings[doc_indices].to(self.device)
 
         # embed the queries and load to device.
-        model, tokenizer = self.dense
-        model.to(self.device)
         query_embeddings = self._get_embeddings(queries).to(self.device)
-        # release the dense model
-        model.cpu()
 
         # compute cosine similarity and scale to [0, 1]
         # shape is len(queries)

--- a/inpars/query_eval.py
+++ b/inpars/query_eval.py
@@ -194,7 +194,10 @@ class QueryEval(torch.nn.Module):
             # and rescale it to [0, 1] so we can regard it as a probability
             # NOTE: this is a coarse approximation because we don't want to compute softmax over the whole corpus.
             #       Instead, we can adjust the weights to make the scores comparable.
-            model_name: torch.cosine_similarity(query_embeddings[model_name], doc_embeddings[model_name]).to(self.device)
+            model_name: 
+                (1 + torch.cosine_similarity(
+                        query_embeddings[model_name], doc_embeddings[model_name]).to(self.device)
+                 ) / 2
             for model_name in self.doc_embeddings.keys()
             if model_name != "bm25"
         })

--- a/inpars/query_eval.py
+++ b/inpars/query_eval.py
@@ -1,11 +1,14 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Tuple
+import logging
+from pathlib import Path
+
 import torch
+import numpy as np
+import pandas as pd
 from transformers import AutoTokenizer, AutoModel
 from collections import OrderedDict
-from rank_bm25 import BM25Okapi as BM25
+from bm25s import BM25
 from tqdm.auto import tqdm
-from pathlib import Path
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +29,8 @@ class QueryEval(torch.nn.Module):
             else:
                 self.tokenizers[model] = AutoTokenizer.from_pretrained(model)
                 self.models[model] = AutoModel.from_pretrained(model).to(self.device)
-        self.weights = torch.tensor(weights, device=self.device)
-        self.doc_embeddings = None
+        self.weights = OrderedDict({model: weight for model, weight in zip(models, weights)})
+        self.doc_embeddings = OrderedDict()
 
     def _mean_pooling(self, token_embeddings: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         """Perform mean pooling on token embeddings using attention mask"""
@@ -38,11 +41,10 @@ class QueryEval(torch.nn.Module):
         """
             Compute embeddings for a list of documents
             Inputs:
-                documents: List of document texts
-                batch_size: Batch size for processing
+                model_name: Name of the model to use
+                documents: A list of D documents
             Returns:
-                List of embeddings for each (dense) model and document in the input list
-                so a list of shape (num_models, num_documents, model_embedding_dim)
+                List of embeddings for the given documents computed by the given model.
         """
         embeddings = []
         if model_name not in self.tokenizers:
@@ -50,114 +52,184 @@ class QueryEval(torch.nn.Module):
 
         tokenizer = self.tokenizers[model_name]
         model = self.models[model_name]
-        embeddings = torch.zeros((len(documents), model.config.hidden_size), device=self.device)
         with torch.no_grad():
-            for i in tqdm(range(0, len(documents), batch_size), desc=f"Compute embeddings using {model_name}"):
-                batch = documents[i:i+batch_size]
-                inputs = tokenizer(batch, padding=True, truncation=True, return_tensors='pt').to(self.device)
-                outputs = model(**inputs)
-                outputs = self._mean_pooling(outputs.last_hidden_state, inputs['attention_mask']).to(self.device)
-                embeddings[i:i+batch_size] = outputs
+            inputs = tokenizer(documents, padding=True, truncation=True, return_tensors='pt').to(self.device)
+            outputs = model(**inputs)
+            embeddings = self._mean_pooling(outputs.last_hidden_state, inputs['attention_mask']).to(self.device)
 
         # sanity check
         assert embeddings.shape[0] == len(documents), f"sanity check failed: {embeddings.shape[0]} != {len(documents)}"
-        assert embeddings.shape[1] == outputs.size(-1), f"sanity check failed: {embeddings.shape[1]} != {outputs.size(-1)}"
+        assert embeddings.shape[1] == model.config.hidden_size, f"sanity check failed: {embeddings.shape[1]} != {outputs.size(-1)}"
         return embeddings
 
-    def _load_cached_embeddings(self, cache_path: Path) -> None:
-        """Load precomputed embeddings from cache"""
+    def load_from_cache(self, cache_path: Path) -> None:
+        """Load precomputed embeddings from cache.
+        Args:
+            cache_path: Path to the cache file
+        Loads a pandas DataFrame with columns ['doc_id', 'embedding'] from the cache file.
+        """
         self.doc_embeddings = torch.load(cache_path)
+        if "bm25" in self.models:
+            self.models["bm25"] = BM25.load(
+                cache_path.parent.absolute() / f"{cache_path.stem}_bm25{cache_path.suffix}")
+
+    def save_to_cache(self, cache_path: Path) -> None:
+        """Save precomputed embeddings to cache.
+        Args:
+            cache_path: Path to the cache file
+        Saves a pandas DataFrame with columns ['doc_id', 'embedding'] to the cache file.
+        """
+        torch.save(self.doc_embeddings, cache_path)
+        if "bm25" in self.models:
+            self.models["bm25"].save(cache_path.parent.absolute(
+            ) / f"{cache_path.stem}_bm25{cache_path.suffix}")
 
     def load_dataset(self,
-                     documents: Optional[List[str]] = None,
-                     cache_path: Optional[Path] = None,
+                     documents: pd.DataFrame,
                      batch_size: int = 32
                      ) -> None:
-        """Precompute and store embeddings for the document dataset"""
-        if cache_path is not None and cache_path.exists():
-            logger.info(f"Loading embeddings from cache: {cache_path}")
-            self._load_cached_embeddings(cache_path)
-            return
+        """
+            Precompute and store embeddings for the document dataset.
+            Inputs:
+                documents: DataFrame with columns ['doc_id', 'text']
+                batch_size: Batch size for processing
+            Loads the embeddings into self.doc_embeddings as 
+            a dictionary of model_name ->
+                pd.DataFrame objects with columns ['doc_id', 'embedding']
+            if bm25 is used, the plain text documents are stored in self.doc_embeddings["bm25"]
+        """
         if documents is None:
             raise ValueError("No documents nor a valid path provided to load_dataset.")
 
-        def load_for_model(model_name) -> Union[BM25, torch.Tensor]:
+        def embed_for_model(model_name) -> Union[Dict[str, Tuple[int, List[str]]], pd.DataFrame]:
+            """
+            Compute embeddings for the given corpus and model.
+            - If the model is a BM25 model, return the tokenized text, 
+                including the integer index of the documents in the corpus.
+                We need these indices to identify the documents in the output
+                of the BM25.get_scores method.
+            - Otherwise, embed the documents in batches and
+                store the embeddings in a pd.DataFrame.
+            """
             if model_name == "bm25":
-                return BM25([doc.split() for doc in documents])
-            return self._get_embeddings(model_name, documents, batch_size)
-
-        self.doc_embeddings = {model_name: load_for_model(model_name)
-                               for model_name in self.models.keys()}
+                texts = OrderedDict({
+                    doc_id: (idx, text.split()) for idx, (doc_id, text) in enumerate(documents[['doc_id', 'text']].values)
+                })
+                # split the text into tokens
+                return texts
+            # otherwise, iterate over the list of documents,
+            # embed them in batches and
+            # store the embeddings in a pd.DataFrame
+            embeddings = pd.DataFrame(columns=['doc_id', 'embedding'])
+            for i in tqdm(range(0, len(documents), batch_size), desc=f"Computing embeddings for {model_name}"):
+                batch = documents[i:i + batch_size]
+                embeddings_batch = self._get_embeddings(model_name, batch['text'].tolist(), batch_size)
+                embeddings = pd.concat([embeddings, pd.DataFrame({
+                    'doc_id': batch['doc_id'].tolist(),
+                    'embedding': embeddings_batch.cpu().tolist()
+                })], ignore_index=True)
+            return embeddings
 
         logger.info("Computing embeddings for %d models", len(self.models))
+        self.doc_embeddings = OrderedDict({model_name: embed_for_model(model_name)
+                               for model_name in self.models.keys()})
+
         if "bm25" in self.doc_embeddings:
-            self.models["bm25"] = self.doc_embeddings["bm25"]
-            del self.doc_embeddings["bm25"]
+            self.models["bm25"] = BM25()
+            self.models["bm25"].index([text for _, text in self.doc_embeddings["bm25"].values()])
+
         # sanity
-        assert all([embeddings.shape[1] == self.models[model_name].config.hidden_size
-                    for model_name, embeddings in self.doc_embeddings.items()]), f"sanity check: model embedding doesn't match with the model's hidden size"
+        assert all([len(embeddings["embedding"].to_numpy()[0]) == self.models[model_name].config.hidden_size
+                    for model_name, embeddings in self.doc_embeddings.items()
+                    if model_name != "bm25"]), f"sanity check: model embedding doesn't match with the model's hidden size"
+
         logger.info("Document embeddings computed successfully")
-        # cache embeddings
-        if cache_path is not None:
-            torch.save(self.doc_embeddings, cache_path)
-            logger.info(f"Embeddings saved to {cache_path}")
 
     def score(self,
-                query: Union[str, List[str]],
-                doc_indices: Optional[List[int]] = None,
+                queries: Union[str, List[str]],
+                doc_indices: Union[str, List[int]] = None,
                 batch_size: int = 32) -> torch.Tensor:
         """Compute similarity scores between query and documents.
 
         Args:
-            query: Query text or list of query texts
-            doc_indices: Optional list of document indices to score against.
-                        If None, scores against all documents.
+            query: a batch of queries
+            doc_indices: a batch of document indices, each corresponding to an input query
 
         Returns:
-            Array of similarity scores
+            For each query-document pair in the batch, a similarity score, i.e.
+            (q1 ~ d1, q2 ~ d2, ..., qn ~ dn)
         """
         if self.doc_embeddings is None:
             raise ValueError("No document embeddings found. Call load_dataset first.")
 
         logger.info("Computing similarity scores")
-        if isinstance(query, str):
-            query = [query]
+        if isinstance(queries, str):
+            queries = [queries]
+        if isinstance(doc_indices, int):
+            doc_indices = [doc_indices]
+        if len(queries) != len(doc_indices):
+            raise ValueError("Number of queries and document indices should be the same.")
 
-        query_embeddings = [self._get_embeddings(model_name, query, batch_size)
-                            for model_name in self.doc_embeddings]
+        # find the embeddings corresponding to the doc_indices in the dataframes
+        doc_embeddings = OrderedDict({
+            model_name: torch.tensor(
+                self.doc_embeddings[model_name].loc[
+                    self.doc_embeddings[model_name]['doc_id'].isin(doc_indices), 'embedding'
+                ].values.tolist(),
+                device=self.device
+            )
+            for model_name in self.doc_embeddings.keys()
+            if model_name != "bm25"
+        })
 
-        if doc_indices is not None:
-            doc_embeddings = [self.doc_embeddings[model_name][doc_indices] for model_name in self.doc_embeddings]
-        else:
-            doc_embeddings = [emb for emb in self.doc_embeddings.values()]
+        # embed the queries in the same order
+        query_embeddings = OrderedDict({model_name: self._get_embeddings(model_name, queries, batch_size)
+                                        for model_name in self.doc_embeddings.keys()
+                                        if model_name != "bm25"})
 
-        similarities = []
-        for q_emb, d_emb in zip(query_embeddings, doc_embeddings):
-            q_emb = q_emb.to(self.device)
-            d_emb = d_emb.to(self.device)
-            similarities.append(torch.einsum('ij,kj->ik', q_emb, d_emb).cpu().squeeze())
+        # embedding dimensions differ from model to model,
+        # so we have to do one by one
+        similarities = OrderedDict({
+            # compute cosine similarity between query and document embeddings
+            # and rescale it to [0, 1] so we can regard it as a probability
+            # NOTE: this is a coarse approximation because we don't want to compute softmax over the whole corpus.
+            #       Instead, we can adjust the weights to make the scores comparable.
+            model_name: torch.cosine_similarity(query_embeddings[model_name], doc_embeddings[model_name]).to(self.device)
+            for model_name in self.doc_embeddings.keys()
+            if model_name != "bm25"
+        })
+        # do the same for BM25
         if "bm25" in self.models:
-            for q in query:
-                # BM25Okapi uses np arrays
-                similarities.append(
-                    torch.tensor(self.models["bm25"].get_batch_scores(q.split(), doc_indices), device='cpu').squeeze())
-        logger.debug("similarities: %s", similarities)
-        similarities = torch.stack(similarities).to(self.device)
-        logger.debug("after stacking: %s\nshape: %s", similarities, similarities.shape)
+            # select the numeric indices of the requested documents
+            doc_idxs = [self.doc_embeddings["bm25"][d][0] for d in doc_indices]
+            scores = []
+            for q, d in zip(queries, doc_idxs):
+                bm25: BM25 = self.models["bm25"]
+                # compute raw bm25 scores for all the documents in the corput
+                alldocs = torch.tensor(bm25.get_scores(q.split()))
+                # send to device
+                alldocs = alldocs.to(self.device).squeeze()
+                # normalise to get "probabilities" 
+                # opposed to dense vectors, here we have no choice but to consider the whole corpus.
+                alldocs = alldocs.softmax(dim=0)
+                # select the score of the requested document
+                scores.append(alldocs[d])
+            similarities["bm25"] = torch.tensor(scores).to(self.device)
+
+        # apply weights
+        similarities = torch.stack([
+                similarities[model_name] * self.weights[model_name]
+                for model_name in similarities.keys()
+            ]).to(self.device)
         # compute weighted average of similarities
-        logger.debug("computing mean, with sim\n %s\nweights\n%s\n and shapes %s  --  %s",
-                    str(similarities), str(self.weights), similarities.shape, self.weights.shape)
-        similarities = similarities.T * self.weights
-        weighted_mean = torch.mean(similarities)
+        weighted_mean = torch.mean(similarities, dim=0)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Overall similarity score: %s", weighted_mean)
-            for model_name, sim in zip(
-                    filter(lambda m: m != "bm25", self.models.keys()),
-                    similarities):
+            for model_name, sim in similarities.items():
                 logger.debug("Similarity score using %s: %s", model_name, sim)
             if "bm25" in self.models:
-                logger.debug("Similarity score using BM25: %s", similarities[-1])
+                logger.debug("Similarity score using BM25: %s", similarities["bm25"])
 
         return weighted_mean.squeeze()
 
@@ -167,11 +239,12 @@ class QueryEval(torch.nn.Module):
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     logger.setLevel(logging.DEBUG)
-    documents = [
-        "The quick brown fox jumps over the lazy dog.",
-        "A fast brown fox leaps over a sleepy dog.",
-        "The lazy dog lies in the sun."
-    ]
+    documents = pd.DataFrame({'doc_id': ['d1', 'd2', 'd3'],
+                              'text': [
+                                "The quick brown fox jumps over the lazy dog.",
+                                "A fast brown fox leaps over a sleepy dog.",
+                                "The lazy dog lies in the sun."
+                             ]})
     query = "quick brown fox"
 
     query_eval = QueryEval()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = inpars

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,19 +69,6 @@ namex==0.0.8
 networkx==3.4.2
 nmslib==2.0.6
 numpy==2.0.2
-nvidia-cublas-cu12==12.4.5.8
-nvidia-cuda-cupti-cu12==12.4.127
-nvidia-cuda-nvrtc-cu12==12.4.127
-nvidia-cuda-runtime-cu12==12.4.127
-nvidia-cudnn-cu12==9.1.0.70
-nvidia-cufft-cu12==11.2.1.3
-nvidia-curand-cu12==10.3.5.147
-nvidia-cusolver-cu12==11.6.1.9
-nvidia-cusparse-cu12==12.3.1.170
-nvidia-nccl-cu12==2.21.5
-nvidia-nvjitlink-cu12==12.4.127
-nvidia-nvtx-cu12==12.4.127
-onnxruntime==1.20.0
 openai==1.54.1
 opt_einsum==3.4.0
 optree==0.13.0
@@ -154,4 +141,5 @@ wrapt==1.16.0
 xxhash==3.5.0
 yarl==1.17.1
 zlib-state==0.1.9
-rank-bm25==0.2.2
+bm25s==0.1.0
+pytest==8.3.3

--- a/scripts/run_pytest.job
+++ b/scripts/run_pytest.job
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#SBATCH --partition=gpu
+#SBATCH --gpus=1
+
+#SBATCH --job-name=PYTEST
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --time=00:59:00
+#SBATCH --mem=3000M
+#SBATCH --output=logs/pytest_%A.out
+#SBATCH --error=logs/pytest_%A.err
+
+#SBATCH --ear=on
+#SBATCH --ear-policy=monitoring
+#SBATCH --ear-verbose=1
+
+# make sure the correct modules are used and that the virtual environment is active
+PROJECT_ROOT=/home/$USER/IR2-project
+source $PROJECT_ROOT/scripts/snellius_setup.sh
+setup $PROJECT_ROOT
+
+# TODO: specify job_name, output and error arguments (above)
+cd $PROJECT_ROOT
+# rest of the script
+srun pytest

--- a/tests/test_query_eval.py
+++ b/tests/test_query_eval.py
@@ -4,6 +4,7 @@ import pandas as pd
 import torch
 from pathlib import Path
 from query_eval import QueryEval
+from bm25s import BM25
 
 @pytest.fixture
 def documents():
@@ -30,27 +31,32 @@ def query_eval():
 
 def test_load_dataset(documents, query_eval):
     query_eval.load_dataset(documents)
-    assert "bm25" in query_eval.models
-    assert len(query_eval.doc_embeddings) == 2  # bm25 and one transformer model
-    assert "bm25" in query_eval.doc_embeddings
-    assert "sentence-transformers/all-mpnet-base-v2" in query_eval.doc_embeddings
+    assert isinstance (query_eval.bm25, BM25)
+    assert query_eval.doc_embeddings is not None
+    assert query_eval.doc_embeddings.shape[0] == 3
 
 def test_save_and_load_cache(documents, query_eval, tmp_path):
     query_eval.load_dataset(documents)
-    cache_path = tmp_path / "cache.pt"
+    cache_path = tmp_path / "cache"
     query_eval.save_to_cache(cache_path)
     assert cache_path.exists()
+    index_path = cache_path / "index.json"
+    embedding_path = cache_path / "embeddings.pt"
+    bm25_path = cache_path / "bm25.pkl"
+    assert index_path.exists()
+    assert embedding_path.exists()
+    assert bm25_path.exists()
 
     new_query_eval = QueryEval()
     new_query_eval.load_from_cache(cache_path)
-    assert new_query_eval.doc_embeddings.keys() == query_eval.doc_embeddings.keys()
+    assert torch.all(new_query_eval.doc_embeddings == query_eval.doc_embeddings)
 
 def test_score_single_query_single_doc(documents, queries, query_eval):
     query_eval.load_dataset(documents)
-    score = query_eval.score(queries[0], ['d1'])
+    score = query_eval.score(queries[0], 'd1')
     assert isinstance(score, torch.Tensor)
     assert score.dim() == 0  # should be a scalar
-    bad_score = query_eval.score(queries[0], ['d2'])
+    bad_score = query_eval.score(queries[0], 'd2')
     assert score > bad_score, "Score should be higher for relevant document"
 
 def test_score_batch_queries(documents, queries, query_eval):

--- a/tests/test_query_eval.py
+++ b/tests/test_query_eval.py
@@ -1,0 +1,67 @@
+
+import pytest
+import pandas as pd
+import torch
+from pathlib import Path
+from query_eval import QueryEval
+
+@pytest.fixture
+def documents():
+    return pd.DataFrame({
+        'doc_id': ['d1', 'd2', 'd3'],
+        'text': [
+            "The quick brown fox jumps over the lazy dog.",
+            "A fast brown fox leaps over a sleepy dog.",
+            "The lazy dog lies in the sun."
+        ]
+    })
+
+@pytest.fixture
+def queries():
+    return [
+        "quick brown fox",
+        "fast brown fox",
+        "lazy dog"
+    ]
+
+@pytest.fixture
+def query_eval():
+    return QueryEval()
+
+def test_load_dataset(documents, query_eval):
+    query_eval.load_dataset(documents)
+    assert "bm25" in query_eval.models
+    assert len(query_eval.doc_embeddings) == 2  # bm25 and one transformer model
+    assert "bm25" in query_eval.doc_embeddings
+    assert "sentence-transformers/all-mpnet-base-v2" in query_eval.doc_embeddings
+
+def test_save_and_load_cache(documents, query_eval, tmp_path):
+    query_eval.load_dataset(documents)
+    cache_path = tmp_path / "cache.pt"
+    query_eval.save_to_cache(cache_path)
+    assert cache_path.exists()
+
+    new_query_eval = QueryEval()
+    new_query_eval.load_from_cache(cache_path)
+    assert new_query_eval.doc_embeddings.keys() == query_eval.doc_embeddings.keys()
+
+def test_score_single_query_single_doc(documents, queries, query_eval):
+    query_eval.load_dataset(documents)
+    score = query_eval.score(queries[0], ['d1'])
+    assert isinstance(score, torch.Tensor)
+    assert score.dim() == 0  # should be a scalar
+    bad_score = query_eval.score(queries[0], ['d2'])
+    assert score > bad_score, "Score should be higher for relevant document"
+
+def test_score_batch_queries(documents, queries, query_eval):
+    query_eval.load_dataset(documents)
+    scores = query_eval.score(queries, ['d1', 'd2', 'd3'])
+    assert isinstance(scores, torch.Tensor)
+    assert scores.shape[0] == 3  # should have three scalars
+    bad_scores = query_eval.score(queries, ['d2', 'd3', 'd1'])
+    assert all(scores > bad_scores), "Scores should be higher for relevant documents"
+
+
+def test_query_doc_len_mismatch(queries, query_eval):
+    with pytest.raises(ValueError):
+        query_eval.score(queries[0], ['d1', 'd2', 'd3'])


### PR DESCRIPTION
good to go from my side

USAGE:
- constructor:
  - list of model names from huggingface + "bm25" if you want to use it.
  - list of weights for each model to use in the weighted sum (see `QueryEval.score()`)
- load_dataset: given a DataFrame (following the format of `.dataset.load_corpus`), compute embeddings for each model and index the corpus for the BM25 model if specified.
- save_to_cache: save the embeddings for the models and the indexed corpus for the BM25 model
- load_from_cache: 
- score: given a list of queries $(q_1,q_2,\dots,q_n)$ and a list of documents $(d_1,d_2,\dots,d_n)$, compute 

<img width="589" alt="image" src="https://github.com/user-attachments/assets/87998dbc-c2a6-4c49-99bd-1c1404c62542">

In words, the score function takes a bunch of query-document pairs, and for each such pair, it computes a list of similarity scores (in the range $[0,1]$) and takes their weighted average.

NOTE:
- The `score` function *approximates the likelihood* that a given query refers to a given document. It does not "rank" the documents in any traditional way.
- For dense models, we don't want to compute similarity scores for all documents in the corpus because it is expensive. Instead, we take the *cosine similarity* (scaled to $[0,1]$) and regard it as it if were a probability.
- We cannot do the same with the BM25 score, because its output domain is unbounded. So, we *have to* score all documents in the corpus, compute softmax and take the value computed for the given document.
- Currently, we control the weights and the list of models that we use in the constructor. In the future, we might want to consider fitting the weights to the training set (because, since cosine similarity $\neq$ probability, the scores might not be on the same scale still. A good way to overcome this is by fitting the scores on actual query-document pairs)